### PR TITLE
Build with Visual Studio 2012

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -34,6 +34,7 @@
 #include <functional>
 #include <algorithm>
 #include <numeric>
+#include <memory>
 
 #include "Utility.h"
 #include "OdbcException.h"


### PR DESCRIPTION
Apparently <memory> was being included as a side effect of another header include in Visual Studio 2011.  To build on 2012, I needed to add the include explicitly to stdafx.h.

Steps to build in Visual Studio 2012:

Run "node-gyp configure"
Open "build\sqlserver.vcxproj" in visual studio 2012
Visual Studio will ask if you want to update.  Agree, then save all changes.
Run "node-gyp build"
