### PR TITLE
  Change Codepage for error messages to utf-8 because German letters were lost.

### DIFF
--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -47,12 +47,12 @@ namespace mssql
     string w2a(const wchar_t* input)
     {
         vector<char> messageBuffer;
-        int length = ::WideCharToMultiByte(CP_ACP, 0, input, -1, nullptr, 0, nullptr, nullptr);
+        int length = ::WideCharToMultiByte(CP_UTF8, 0, input, -1, nullptr, 0, nullptr, nullptr);
         if (length > 0)
         {
             // length includes null terminator
             messageBuffer.resize(length);
-            ::WideCharToMultiByte(CP_ACP, 0, input, -1, messageBuffer.data(), messageBuffer.size(), nullptr, nullptr);
+            ::WideCharToMultiByte(CP_UTF8, 0, input, -1, messageBuffer.data(), messageBuffer.size(), nullptr, nullptr);
         }
         return string(messageBuffer.data());
     }


### PR DESCRIPTION
see issue #133
