### PR TITLE
Make install script work for node.js version 0.10.x

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -13,6 +13,10 @@ console.log( "You are downloading Microsoft Driver for Node.js for SQL Server fr
 
 var msiVer = process.version.split(".").slice(0,2).join(".");
 var msiArch = process.arch;
+// if your node version > v0.8, we need to use v0.8
+if (msiVer == "v0.10") {
+  msiVer = "v0.8" ;
+}
 var msiName = "msnodesql-" + package.version + "-" + msiVer + "-" + msiArch + ".msi";
 var msiUrl = {
   host: 'download.microsoft.com',


### PR DESCRIPTION
Microsoft Driver for Node.JS for SQL Server has not been updated for
node.js version 0.10.x, therefore we have to use v0.8 msi package.
